### PR TITLE
Fetch and display images on the criminal profile page

### DIFF
--- a/src/routes/[id].svelte
+++ b/src/routes/[id].svelte
@@ -2,6 +2,7 @@
     import { onMount } from "svelte";
     import defaultProfilePicture from '../assets/images/defaultProfilePicture.png';
     import type { ExtendedNotice } from "../types/ExtendedNotice";
+    import type { ImagesResponse } from "../types/ImagesResponse";
 
     export let params: { id: string } = { id: '' };
     $: id = params.id;
@@ -33,6 +34,8 @@
             chargeTranslation: string | null;
         }[];
 
+        public imagesLinks: string[];
+
         constructor(href: string) {
             this.name = "Unknown";
             this.forename = "Unknown";
@@ -55,6 +58,8 @@
             this.languagesSpokenIds = [];
 
             this.arrestWarrants = [];
+
+            this.imagesLinks = [];
         }
 
         async run() {
@@ -93,8 +98,11 @@
             this.height = data.height;
             this.hairsId = data.hairs_id;
             this.eyesColorsId = data.eyes_colors_id;
-
+            
             this.distinguishingMarks = data.distinguishing_marks;
+            if(this.distinguishingMarks) {
+                this.distinguishingMarks = data.distinguishing_marks!.split(' ').map((mark) => mark.charAt(0).toUpperCase() + mark.slice(1).toLowerCase()).join(' ');
+            }
 
             this.languagesSpokenIds = data.languages_spoken_ids;
 
@@ -103,6 +111,10 @@
                 issuingCountryId: warrant.issuing_country_id,
                 chargeTranslation: warrant.charge_translation
             }));
+
+            const imagesResponse = await fetch(data._links.images.href);
+            let imagesData: ImagesResponse = await imagesResponse.json();
+            this.imagesLinks = imagesData._embedded.images.map(image => image._links.self.href);
         }
     }
 
@@ -113,15 +125,13 @@
         criminal = new Criminal(`https://ws-public.interpol.int/notices/v1/red/${id}`);
         await criminal.run();
         dataFetched = true;
-
-        console.log(criminal);
     });
 </script>
 
 <div class="w-full">
     {#if dataFetched}
     <h1 class="text-3xl sm:text-4xl md:text-5xl text-center text-white mb-5">{criminal.name + " " + criminal.forename}</h1>
-        <div class="flex flex-col md:flex-row items-start justify-center gap-5 p-4 text-white w-full">
+        <div class="flex flex-col md:flex-row justify-center gap-5 p-4 text-white w-full">
             <aside class="w-full md:w-1/3 flex flex-col gap-2 p-4 font-bold">
                 <img class="rounded-lg w-full md:w-64" src={criminal.profilePicturePath || defaultProfilePicture} alt="" draggable="false" />
                 <div class="flex items-center gap-3">
@@ -164,20 +174,28 @@
                     <p>Hairs: <span class="font-normal">{criminal.hairsId}</span></p>
                 {/if}
             </aside>
-            <div class="w-full md:w-2/3 h-full flex flex-col gap-2 justify-start p-4">
-                <h2 class="font-bold text-xl">Arrest warrants:</h2>
-                <ul>
-                    {#each criminal.arrestWarrants as warrant}
-                        <li>
-                            {warrant.charge}
-                        </li>
+            <div class="w-full md:w-2/3 p-4 flex flex-col justify-between gap-5">
+                <div class="flex flex-col gap-2 justify-start">
+                    <h2 class="font-bold text-xl flex-grow">Arrest warrants:</h2>
+                    <ul>
+                        {#each criminal.arrestWarrants as warrant}
+                            <li>
+                                {warrant.charge}
+                            </li>
+                        {/each}
+                    </ul>
+    
+                    {#if criminal.distinguishingMarks}
+                        <h2 class="font-bold text-xl mt-3">Distinguishing marks:</h2>
+                        <p>{criminal.distinguishingMarks}</p>
+                    {/if}
+                </div>
+                
+                <div class="flex justify-center md:justify-start flex-wrap gap-4">
+                    {#each criminal.imagesLinks as imageLink}
+                        <img class="rounded-lg w-60" src={imageLink} alt="" draggable="false" />
                     {/each}
-                </ul>
-
-                {#if criminal.distinguishingMarks}
-                    <h2 class="font-bold text-xl mt-3">Distinguishing marks:</h2>
-                    <p>{criminal.distinguishingMarks}</p>
-                {/if}
+                </div>
             </div>
         </div>
     {/if}

--- a/src/types/ImagesResponse.ts
+++ b/src/types/ImagesResponse.ts
@@ -1,0 +1,23 @@
+export interface ImagesResponse {
+    _embedded: {
+        images: {
+            picture_id: string;
+            _links: {
+                self: {
+                    href: string;
+                };
+            };
+        }[];
+    };
+    _links: {
+        self: {
+            href: string;
+        };
+        notice: {
+            href: string;
+        };
+        thumbnail: {
+            href: string;
+        };
+    };
+}


### PR DESCRIPTION
This pull request includes several changes to the `src/routes/[id].svelte` file to enhance the display of criminal images and improve the formatting of distinguishing marks. Additionally, a new type definition for `ImagesResponse` has been added.