### PR TITLE
Properly import Tailwind CSS in app.css

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,6 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss/base";
+@import "tailwindcss/components";
+@import "tailwindcss/utilities";
 
 * {
   margin: 0;


### PR DESCRIPTION
This pull request includes a small change to the `src/app.css` file. The change updates the way Tailwind CSS is imported to use the `@import` syntax instead of the `@tailwind` directive.